### PR TITLE
Fixed a bug that caused image mark escaping to fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "coverageDirectory": "coverage",
     "coverageProvider": "v8",
     "preset": "ts-jest",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "modulePathIgnorePatterns": ["dist"]
   },
   "dependencies": {
     "commander": "^9.1.0",

--- a/src/readImageMark/index.spec.ts
+++ b/src/readImageMark/index.spec.ts
@@ -29,22 +29,22 @@ test("readImageMark should return ImageParams from valid image marks", async () 
 
   expect(imageParams[0]).toEqual({
     pageName: "sample1",
-    selector: "/html/body/div[5]/div/main/div[2]",
+    selector: "//html//body//div[5]//div//main//div[2]",
     savePath: "sample1.png",
   });
   expect(imageParams[1]).toEqual({
     pageName: "sample2",
-    selector: "/html/body/div[5]/div/main/div[2]",
+    selector: "//html//body//div[5]//div//main//div[2]",
     savePath: "sample2.png",
   });
   expect(imageParams[2]).toEqual({
     pageName: "sample3",
-    selector: "/html/body/div[5]/div/main/div[2]",
+    selector: "//html//body//div[5]//div//main//div[2]",
     savePath: "sample3.png",
   });
   expect(imageParams[3]).toEqual({
     pageName: "sample4",
-    selector: "/html/body/div[5]/div/main/div[2]",
+    selector: "//html//body//div[5]//div//main//div[2]",
     savePath: "sample4.png",
   });
   expect(imageParams[4]).toEqual({

--- a/src/readImageMark/index.ts
+++ b/src/readImageMark/index.ts
@@ -23,7 +23,7 @@ const parseImageMark = (imageMark: string): ImageParam => {
   }
   return {
     pageName: result.pageName,
-    selector: result.selector?.replace("/", "//"),
+    selector: result.selector?.replace(/\//g, "//"),
     savePath: result.savePath,
   };
 };


### PR DESCRIPTION
Fixed an omission of escaping slashes in the image markings.